### PR TITLE
Fix velocihelk-vm sensitive attribute of SSH key

### DIFF
--- a/azure/modules/velocihelk-vm/2-virtual-machine.tf
+++ b/azure/modules/velocihelk-vm/2-virtual-machine.tf
@@ -8,7 +8,10 @@ resource "tls_private_key" "example_ssh" {
     rsa_bits = 4096
 }
 # Enable if you want to see the SSH key - It is written to a file
-output "tls_private_key" { value = tls_private_key.example_ssh.private_key_pem }
+output "tls_private_key" { 
+  value = tls_private_key.example_ssh.private_key_pem 
+  sensitive = true
+  }
 
 resource "azurerm_linux_virtual_machine" "vh_vm" {
   name                          = local.virtual_machine_name

--- a/azure/modules/velocihelk-vm/playbook-velociraptor.yml
+++ b/azure/modules/velocihelk-vm/playbook-velociraptor.yml
@@ -1,13 +1,13 @@
 #################################################
-# Playbook: Deploy Velociraptor 
+# Playbook: Deploy Velociraptor
 #################################################
 ---
 - hosts: all
   become: true
 
   tasks:
-    - name: Download Velociraptor for Linux 
-      action: shell curl -L 'https://github.com/iknowjason/BlueTools/blob/main/velociraptor-v0.5.6-linux-amd64.gz?raw=true' -o velociraptor.gz 
+    - name: Download Velociraptor for Linux
+      action: shell curl -L 'https://github.com/iknowjason/BlueTools/blob/main/velociraptor-v0.5.6-linux-amd64.gz?raw=true' -o velociraptor.gz
 
     - name: decompress the Velociraptor gzip
       shell: gzip -d velociraptor.gz
@@ -15,33 +15,33 @@
         chdir: /home/helk
 
     - name: Chmod the Velociraptor binary
-      shell: chmod +x velociraptor 
+      shell: chmod +x velociraptor
       args:
         chdir: /home/helk
 
     - name: Copy the velociraptor binary
-      shell: cp velociraptor /usr/sbin/. 
+      shell: cp velociraptor /usr/sbin/.
       args:
         chdir: /home/helk
 
-    - name: Add admin user credentials of helk:helk 
-      shell: velociraptor --config server.config.yaml user add helk helk --role administrator 
+    - name: Add admin user credentials of helk:helk
+      shell: velociraptor --config server.config.yaml user add vadmin vadmin --role administrator 
       args:
         chdir: /home/helk
 
     - name: Add the self-signed certificate parameter for the client configuration
       replace:
-        path: /home/helk/server.config.yaml 
+        path: /home/helk/server.config.yaml
         regexp: "  pinned_server_name: VelociraptorServer"
         replace: "  use_self_signed_ssl: true\n  pinned_server_name: VelociraptorServer"
 
-    - name: Build a velociraptor deb package 
-      shell: velociraptor --config server.config.yaml debian server 
+    - name: Build a velociraptor deb package
+      shell: velociraptor --config server.config.yaml debian server
       args:
         chdir: /home/helk
 
-    - name: Install deb package and service 
-      shell: dpkg -i velociraptor_0.5.6_server.deb 
+    - name: Install deb package and service
+      shell: dpkg -i velociraptor_0.5.6_server.deb
       args:
         chdir: /home/helk
 

--- a/azure/modules/velocihelk-vm/playbook-velociraptor.yml
+++ b/azure/modules/velocihelk-vm/playbook-velociraptor.yml
@@ -1,13 +1,13 @@
 #################################################
-# Playbook: Deploy Velociraptor
+# Playbook: Deploy Velociraptor 
 #################################################
 ---
 - hosts: all
   become: true
 
   tasks:
-    - name: Download Velociraptor for Linux
-      action: shell curl -L 'https://github.com/iknowjason/BlueTools/blob/main/velociraptor-v0.5.6-linux-amd64.gz?raw=true' -o velociraptor.gz
+    - name: Download Velociraptor for Linux 
+      action: shell curl -L 'https://github.com/iknowjason/BlueTools/blob/main/velociraptor-v0.5.6-linux-amd64.gz?raw=true' -o velociraptor.gz 
 
     - name: decompress the Velociraptor gzip
       shell: gzip -d velociraptor.gz
@@ -15,33 +15,33 @@
         chdir: /home/helk
 
     - name: Chmod the Velociraptor binary
-      shell: chmod +x velociraptor
+      shell: chmod +x velociraptor 
       args:
         chdir: /home/helk
 
     - name: Copy the velociraptor binary
-      shell: cp velociraptor /usr/sbin/.
+      shell: cp velociraptor /usr/sbin/. 
       args:
         chdir: /home/helk
 
-    - name: Add admin user credentials of helk:helk
-      shell: velociraptor --config server.config.yaml user add vadmin vadmin --role administrator 
+    - name: Add admin user credentials of helk:helk 
+      shell: velociraptor --config server.config.yaml user add helk helk --role administrator 
       args:
         chdir: /home/helk
 
     - name: Add the self-signed certificate parameter for the client configuration
       replace:
-        path: /home/helk/server.config.yaml
+        path: /home/helk/server.config.yaml 
         regexp: "  pinned_server_name: VelociraptorServer"
         replace: "  use_self_signed_ssl: true\n  pinned_server_name: VelociraptorServer"
 
-    - name: Build a velociraptor deb package
-      shell: velociraptor --config server.config.yaml debian server
+    - name: Build a velociraptor deb package 
+      shell: velociraptor --config server.config.yaml debian server 
       args:
         chdir: /home/helk
 
-    - name: Install deb package and service
-      shell: dpkg -i velociraptor_0.5.6_server.deb
+    - name: Install deb package and service 
+      shell: dpkg -i velociraptor_0.5.6_server.deb 
       args:
         chdir: /home/helk
 


### PR DESCRIPTION
I wasn't able to build the range due to the following terraform error:
```terraform Expressions used in outputs can only refer to sensitive values if the sensitive attribute is true.```

I'm using the following version:
```terraform -version
Terraform v0.15.0
on linux_amd64
+ provider registry.terraform.io/hashicorp/azurerm v2.46.0
+ provider registry.terraform.io/hashicorp/local v2.1.0
+ provider registry.terraform.io/hashicorp/null v3.1.0
+ provider registry.terraform.io/hashicorp/template v2.2.0
+ provider registry.terraform.io/hashicorp/tls v3.1.0
```
